### PR TITLE
Reset MQTT and Cloud connection on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Panasonic Comfort Cloud MQTT Bridge
 Home-Assistant MQTT bridge for Panasonic Comfort Cloud. 
 
-_Note: Current version has only been tested with model `CS-HZ25UKE` so there might be some problems with other models._
+_Note: Current version has been tested with model `CS-HZ25UKE`, let me know if noticing any problems with other models_
 
 ![HA](/ha-dashboard.png "HA")
 

--- a/pcfmqtt/service.py
+++ b/pcfmqtt/service.py
@@ -7,6 +7,21 @@ from pcfmqtt.device import Device
 from pcfmqtt.events import discovery_event, state_event
 
 
+class SessionWrapper(pcomfortcloud.Session):
+    """
+    Wrapper for changing the version string in session 
+    """
+    def _headers(self):
+        return {
+            "X-APP-TYPE": "1",
+            "X-APP-VERSION": "1.15.1",
+            "X-User-Authorization": self._vid,
+            "User-Agent": "G-RAC",
+            "Accept": "application/json; charset=utf-8",
+            "Content-Type": "application/json; charset=utf-8"
+        }
+
+
 class Service:
     """
     Main service
@@ -26,7 +41,7 @@ class Service:
     
     def connect_to_cc(self):
         self._log.info("Connecting to Panasonic Comfort Cloud..")
-        self._session = pcomfortcloud.Session(self._username, self._password)
+        self._session = SessionWrapper(self._username, self._password)
         self._session.login()
         self._log.info("Reading and populating devices")
         self._devices = {}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='panasonic-comfort-cloud-mqtt',
-    version='0.4.0',
+    version='0.4.1',
     description='Home-Assistant MQTT bridge for Panasonic Comfort Cloud ',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# About

_When encountering serious error even after re-attempt reset the MQTT and Comfort Cloud connection to start from fresh_

## Workaround fix for `forbidden` problem #13

_Temporarily fixes version problem in library dependency causing `forbidden` when logging in_

 