### PR TITLE
Fix version mismatch

### DIFF
--- a/pcfmqtt/service.py
+++ b/pcfmqtt/service.py
@@ -14,7 +14,7 @@ class SessionWrapper(pcomfortcloud.Session):
     def _headers(self):
         return {
             "X-APP-TYPE": "1",
-            "X-APP-VERSION": "1.15.1",
+            "X-APP-VERSION": "1.16.0",
             "X-User-Authorization": self._vid,
             "User-Agent": "G-RAC",
             "Accept": "application/json; charset=utf-8",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='panasonic-comfort-cloud-mqtt',
-    version='0.4.1',
+    version='0.4.2',
     description='Home-Assistant MQTT bridge for Panasonic Comfort Cloud ',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# About

Address error coming from version mismatch -

```
Traceback (most recent call last):
  File "/app/pcfmqtt/service.py", line 83, in start
    if device.update_state(self._session, self._update_interval):
  File "/app/pcfmqtt/device.py", line 92, in update_state
    data = session.get_device(self._id)
  File "/usr/local/lib/python3.9/site-packages/pcomfortcloud/session.py", line 274, in get_device
    raise ResponseError(response.status_code, response.text)
pcomfortcloud.session.ResponseError: Invalid response, status code: 401 - Data: {"message":"New version app has been published","code":4106}
```

## Related 

- https://github.com/lostfields/python-panasonic-comfort-cloud/issues/71