### PR TITLE
Fix version mismatch

### DIFF
--- a/pcfmqtt/service.py
+++ b/pcfmqtt/service.py
@@ -14,7 +14,7 @@ class SessionWrapper(pcomfortcloud.Session):
     def _headers(self):
         return {
             "X-APP-TYPE": "1",
-            "X-APP-VERSION": "1.16.0",
+            "X-APP-VERSION": "1.19.0",
             "X-User-Authorization": self._vid,
             "User-Agent": "G-RAC",
             "Accept": "application/json; charset=utf-8",


### PR DESCRIPTION
Fixes version to match the new app version,

Error,
```
Traceback (most recent call last):
  File "/app/run.py", line 4, in <module>
    __main__.main()
  File "/app/pcfmqtt/__main__.py", line 42, in main
    s.start()
  File "/app/pcfmqtt/service.py", line 79, in start
    self.connect_to_cc()
  File "/app/pcfmqtt/service.py", line 45, in connect_to_cc
    self._session.login()
  File "/usr/local/lib/python3.9/site-packages/pcomfortcloud/session.py", line 99, in login
    self._create_token()
  File "/usr/local/lib/python3.9/site-packages/pcomfortcloud/session.py", line 132, in _create_token
    raise ResponseError(response.status_code, response.text)
pcomfortcloud.session.ResponseError: Invalid response, status code: 401 - Data: {"message":"New version app has been published","code":4106}
```