### PR TITLE
Improved error handling for login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 docker:
 	docker build  . --tag pcc-mqtt
+
+unittest:
+	python3 -m unittest test/*.py

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ To access the logs run,
 
 ### Plans for version 1.0.0
 
-- [ ] Proper documentation
 - [ ] Docker package
 
 ### Beyound 1.x

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='panasonic-comfort-cloud-mqtt',
-    version='0.4.2',
+    version='0.4.4',
     description='Home-Assistant MQTT bridge for Panasonic Comfort Cloud ',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest import mock
+from pcfmqtt.service import Service
+
+class TestService(unittest.TestCase):
+
+    def test_init(self):
+        service = Service("username", "password", "mqtt", 1883, "topic")
+        service._wrapper_mqtt = mock.Mock()
+        service._wrapper_session = mock.Mock()
+        self.assertEqual("topic", service._topic_prefix)
+        self.assertEqual("username", service._username)
+        self.assertEqual("password", service._password)
+        self.assertEqual("mqtt", service._mqtt)
+        self.assertEqual(1883, service._mqtt_port)
+        self.assertEqual(60, service._update_interval)
+        self.assertEqual({}, service._devices)
+        self.assertIsNone(service._client)
+        self.assertIsNone(service._session)
+
+    


### PR DESCRIPTION
# About
_Handle logging errors more gracefully. If encountering one instead of bailing out right away sleep for 10 minutes and try again. This addresses most of the problems caused of PCC being in maintenance / down._

