### PR TITLE
Fix login failure due to missing headers

### DIFF
--- a/pcfmqtt/service.py
+++ b/pcfmqtt/service.py
@@ -16,6 +16,9 @@ class SessionWrapper(pcomfortcloud.Session):
             "X-APP-TYPE": "1",
             "X-APP-VERSION": "1.19.0",
             "X-User-Authorization": self._vid,
+            "X-APP-TIMESTAMP": "1",
+            "X-APP-NAME": "Comfort Cloud",
+            "X-CFC-API-KEY": "Comfort Cloud",
             "User-Agent": "G-RAC",
             "Accept": "application/json; charset=utf-8",
             "Content-Type": "application/json; charset=utf-8"


### PR DESCRIPTION
Adds new headers required for login. 

Fixes error:
```
Service - ERROR - Failed initialization to Panasonic Comfort Cloud: Invalid response, status code: 400 - Data: {"code":"4000"，"message":"Missing required header parameter or bad request for header"}. Will attempt again in 10 minutes.
```

Related conversion,
https://github.com/lostfields/python-panasonic-comfort-cloud/issues/78